### PR TITLE
update paper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![](./pics/teaser.png)
 
-[[Paper]](https://changyu.io/papers/yu2022meshtaichi.pdf) [[Video]](https://www.youtube.com/watch?v=vjBrk7k8SPE) [[Full Talk]](https://www.youtube.com/watch?v=ISSyVKOfS4o)
+[[Paper]](https://tiantianliu.cn/papers/yu22meshtaichi/yu22meshtaichi.pdf) [[Video]](https://www.youtube.com/watch?v=vjBrk7k8SPE) [[Full Talk]](https://www.youtube.com/watch?v=ISSyVKOfS4o)
 
 The MeshTaichi framework is now officially part of [Taichi](https://github.com/taichi-dev/taichi) and can be installed by `pip`. This repo only contains examples.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change (updates an external URL) with no impact on runtime behavior.
> 
> **Overview**
> Updates the `README.md` paper URL to point to the new hosted PDF location, leaving the video/talk links unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e33110bf488e3151f9e887941f7e943946b7dfe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->